### PR TITLE
fix: reuse existing player

### DIFF
--- a/src/services/music.player.service.ts
+++ b/src/services/music.player.service.ts
@@ -69,11 +69,17 @@ const resolveAndPlayTrack = async (
      * We'd have to update the redis entry for the updated voice channel ID
      * if the bot is following someone as well; not worth the hassle.
      */
-    RedisClient.getInstance().delete(guildId);
-    player.destroy();
-    shoukaku.leaveVoiceChannel(guildId);
+    try {
+      await Promise.all([
+        RedisClient.getInstance().delete(guildId),
+        player.destroy(),
+        textChannel.send("I didn't like that. Bye."),
+      ]);
 
-    await textChannel.send("I didn't like that. Bye.");
+      await shoukaku.leaveVoiceChannel(guildId);
+    } catch (err) {
+      logger.error(err);
+    }
   });
 
   const node = shoukaku.options.nodeResolver(shoukaku.nodes);

--- a/src/services/music.player.service.ts
+++ b/src/services/music.player.service.ts
@@ -10,6 +10,7 @@ import { getAverageColor } from 'fast-average-color-node';
 import { LoadType, Player, Shoukaku, Track } from 'shoukaku';
 import { songInfoEmbed } from 'utils/embeds';
 import logger from 'utils/logger';
+import RedisClient from 'utils/redis';
 
 /**
  * Helper function to play music, either from the
@@ -20,21 +21,59 @@ const resolveAndPlayTrack = async (
   shoukaku: Shoukaku,
   guildId: string,
   voiceChannelId: string,
+  textChannel: TextChannel,
   searchPhrase: string,
   sendReply: (
     message: string | { embeds: (typeof songInfoEmbed)[] },
   ) => Promise<void | Message<boolean>>,
 ): Promise<void> => {
-  await shoukaku.leaveVoiceChannel(guildId);
+  const connection = shoukaku.connections.get(guildId.toString());
 
-  const player = await shoukaku.joinVoiceChannel({
-    guildId: guildId,
-    channelId: voiceChannelId,
-    shardId: 0,
-  });
+  // Get existing player if still connected, otherwise join channel
+  let player: Player | undefined;
+
+  if (!connection) {
+    /**
+     * Sometimes the connection doesnt exist after a forced disconnect,
+     * but shoukaku still thinks its connected. To workaround the bug,
+     * we make it leave the channel.
+     */
+    await shoukaku.leaveVoiceChannel(guildId);
+  } else {
+    player = shoukaku.players.get(guildId) as Player;
+    player?.stopTrack();
+  }
+
+  if (!player) {
+    player = await shoukaku.joinVoiceChannel({
+      guildId: guildId,
+      channelId: voiceChannelId,
+      shardId: 0,
+    });
+  }
+
+  // Remove previous event listeners and set new ones
+  player.clean();
 
   player.on('exception', (reason) => {
     logger.error(reason.exception);
+  });
+
+  player.on('closed', async () => {
+    /**
+     * If forced to disconnect/move, then unfollow the user if following them
+     * and leave the channel so Shoukaku closes the connection.
+     *
+     * Choosing not to support moving the bot around voice channels
+     * as there's no proper way to differentiate from disconnections.
+     * We'd have to update the redis entry for the updated voice channel ID
+     * if the bot is following someone as well; not worth the hassle.
+     */
+    RedisClient.getInstance().delete(guildId);
+    player.destroy();
+    shoukaku.leaveVoiceChannel(guildId);
+
+    await textChannel.send("I didn't like that. Bye.");
   });
 
   const node = shoukaku.options.nodeResolver(shoukaku.nodes);
@@ -82,6 +121,9 @@ export const playFromInteraction = async (
   searchPhrase: string,
   shoukaku: Shoukaku,
 ) => {
+  const textChannel = interaction.client.channels.cache.get(
+    interaction.channelId,
+  ) as TextChannel;
   const guildMember = interaction.member as GuildMember;
 
   await interaction.deferReply();
@@ -90,6 +132,7 @@ export const playFromInteraction = async (
     shoukaku,
     interaction.guildId as string,
     guildMember.voice?.channel?.id as string,
+    textChannel,
     searchPhrase,
     async (message) => await interaction.editReply(message),
   );
@@ -109,6 +152,7 @@ export const play = async (
     shoukaku,
     guildId,
     voiceChannelId,
+    textChannel,
     searchPhrase,
     async (message) => await textChannel.send(message),
   );


### PR DESCRIPTION
Bot won't disconnect and reconnect every time the song changes, the existing player will be used. Had to sacrifice the ability to move the bot around channels.